### PR TITLE
Remove global environment references to better support virtual DOMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- Remove global environment references to better support virtual DOMs
+
 ## [1.0.1] - 2019-04-23
 
 ### Changed

--- a/src/actions/focus.js
+++ b/src/actions/focus.js
@@ -2,8 +2,8 @@ import scoped from '../helpers/scoped';
 
 /* istanbul ignore next: the document always has focus during tests so this
  * function is never encountered */
-function isFramed() {
-  return window.self !== window.top && window.frameElement;
+function isFramed({ self, top, frameElement }) {
+  return self !== top && frameElement;
 }
 
 export default function focus(selector) {
@@ -12,16 +12,16 @@ export default function focus(selector) {
     .assert.focusable()
     .assert.f('Failed to focus %s: %e')
   // invoke the native DOM method
-    .do(element => {
+    .do(function(element) {
       // if no document focus and in an iframe, try to steal focus
       /* istanbul ignore next: document always has focus during tests */
-      if (!document.hasFocus() && isFramed()) {
-        window.frameElement.focus();
+      if (!this.$dom.document.hasFocus() && isFramed(this.$dom)) {
+        this.$dom.frameElement.focus();
       }
 
       // document does not have focus
       /* istanbul ignore if: document always has focus during tests */
-      if (!document.hasFocus()) {
+      if (!this.$dom.document.hasFocus()) {
         throw new Error('the document is not focusable');
       }
 

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -17,9 +17,6 @@ const {
 export default class Interactor {
   static isInteractor = isInteractor;
 
-  // default `document.body` scope is lazy for fake DOM enviroments
-  static get defaultScope() { return document.body; }
-
   constructor(options = {}, previous = {}) {
     // a scope selector, element, or function was given
     if (typeof options === 'string' ||
@@ -74,6 +71,7 @@ export default class Interactor {
       })
     });
 
+    // build assert object for this instance
     defineProperty(this, 'assert', {
       enumerable: false,
       configurable: true,
@@ -87,14 +85,20 @@ export default class Interactor {
     }
   }
 
+  get $dom() {
+    // lazy for virtual DOMs
+    return window;
+  }
+
   get $element() {
     let { scope, parent, detached } = get(this);
     let nested = !detached && parent;
 
-    scope = typeof scope === 'function' ? scope() : scope;
-    scope = scope || (!nested && this.constructor.defaultScope);
+    // evaluate scope or set to default when not nested
+    scope = (typeof scope === 'function' ? scope() : scope) ||
+      (!nested && (this.constructor.defaultScope || this.$dom.document.body));
 
-    return $(scope, nested ? parent.$element : undefined);
+    return $(scope, nested ? parent.$element : this.$dom.document);
   }
 
   $(selector) {

--- a/src/properties/focused.js
+++ b/src/properties/focused.js
@@ -1,7 +1,7 @@
 import computed from '../helpers/computed';
 
 export default function focused(selector) {
-  return computed(selector, element => (
-    element === document.activeElement
-  ));
+  return computed(selector, function(element) {
+    return element === this.$dom.document.activeElement;
+  });
 }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,4 +1,10 @@
-export function $(selector, $ctx = document) {
+function isElement(obj) {
+  // safe way to check `instanceof Element` when Element can be in a virtual DOM
+  return obj && 'ownerDocument' in obj && 'defaultView' in obj.ownerDocument &&
+    obj instanceof obj.ownerDocument.defaultView.Element;
+}
+
+export function $(selector, $ctx) {
   let $node = null;
 
   /* istanbul ignore if: sanity check */
@@ -15,7 +21,7 @@ export function $(selector, $ctx = document) {
     }
 
   // if an element was given, return it
-  } else if (selector instanceof Element) {
+  } else if (isElement(selector)) {
     return selector;
 
   // if the selector is falsy, return the context element
@@ -53,5 +59,5 @@ export function $$(selector, $ctx) {
 
   // only return elements
   /* istanbul ignore next: sanity check */
-  return nodes.filter($node => $node instanceof Element);
+  return nodes.filter(isElement);
 }

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -13,7 +13,7 @@ const {
 } = Object;
 
 const propertyBlacklist = [
-  '$', '$$', '$element', 'only', 'assert', meta,
+  '$', '$$', '$dom', '$element', 'only', 'assert', meta,
   'timeout', 'when', 'always', 'do', 'append', 'run', 'then'
 ];
 

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -835,6 +835,7 @@ describe('Interactor', () => {
         'append',
         '$',
         '$$',
+        '$dom',
         '$element',
         'only',
         'assert'
@@ -914,6 +915,7 @@ describe('Interactor', () => {
         'append',
         '$',
         '$$',
+        '$dom',
         '$element',
         'only',
         'assert'

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,8 @@
-import { $ } from '../src/utils/dom';
-export { $ } from '../src/utils/dom';
+import { $ as $find } from '../src/utils/dom';
+
+export function $(selector, ctx) {
+  return $find(selector, ctx || document);
+}
 
 export function injectHtml(html) {
   let $container = document.getElementById('test');


### PR DESCRIPTION
## Purpose

Interactors only refer to globally available references which make virtual / remote DOMs impossible to interact with. Replacing those references with a configurable reference allows those environments to tell interactor what DOM to interact with.

## Approach

A `$dom` getter was added to the base interactor prototype where all DOM references are now derived from. In virtual / remote DOM environments, this getter can be overridden to provide the virtualized or remote DOM (the `window` object).

The `Element` check is preformed where accessing the new `$dom` getter isn't easy to do. So it was replaced with a function that looks up the element's prototype properties to find the owner document's own `Element` constructor to compare against.