### PR TITLE
Remove click action focusable check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.2.0] - 2019-04-10
+
 ### Changed
 
 - `click` action no longer checks if element is focusable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- `click` action no longer checks if element is focusable
+
 ## [1.1.0] - 2019-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/actions/click.js
+++ b/src/actions/click.js
@@ -3,7 +3,6 @@ import scoped from '../helpers/scoped';
 export default function click(selector) {
   return scoped(selector)
   // perform clickable validation
-    .assert.focusable()
     .assert.not.disabled()
     .assert.f('Failed to click %s: %e')
   // invoke the native DOM method

--- a/tests/actions/click.test.js
+++ b/tests/actions/click.test.js
@@ -31,13 +31,6 @@ describe('Interactor actions - click', () => {
       expect(test.result).toBe(true);
     });
 
-    it('eventually throws an error when clicking a non-clickable element', async () => {
-      let test = testDOMEvent('.test-div', 'click');
-      let div = new Interactor('.test-div').timeout(50);
-      await expect(div.click()).rejects.toThrow('Failed to click ".test-div": is not focusable');
-      expect(test.result).toBe(false);
-    });
-
     it('eventually throws an error when clicking a disabled element', async () => {
       let test = testDOMEvent('button', 'click');
       let button = new Interactor('button').timeout(50);
@@ -71,7 +64,6 @@ describe('Interactor actions - click', () => {
 
     it('clicks the root element when unspecified', async () => {
       let test = testDOMEvent('.test-div', 'click');
-      test.$element.tabIndex = 0;
       await new TestInteractor().clickDiv();
       expect(test.result).toBe(true);
     });


### PR DESCRIPTION
## Purpose

This assertion was initially to provide some basic a11y checking but it turns out that an element can be considered interactive without being focusable if it has one of the widget roles.

Supporting roles will be a slippery slope for making other actions behave accessibly, such as the `select` action working with custom listbox elements. For now we can remove this focusable check and maybe in the future reconsider a11y.

## Approach

Removed the focusable assertion from the click action and updated click tests.

### TODO

- Release docs update when this PR is merged