### PR TITLE
[Docs] Update click API docs to remove focusable assertion

### DIFF
--- a/src/content/actions/click.md
+++ b/src/content/actions/click.md
@@ -21,8 +21,7 @@ await new Interactor('.form').click('.submit');
 ```
 
 <!-- hint: warning -->
-The `click()` method will first assert that the element can be focused and is
-not disabled.
+The `click()` method will first assert that the element is not disabled.
 <!-- endhint -->
 
 ## Action
@@ -48,6 +47,5 @@ await new FormInteractor('.form').submit();
 ```
 
 <!-- hint: warning -->
-The `click()` action will first assert that the element can be focused and is
-not disabled.
+The `click()` action will first assert that the element is not disabled.
 <!-- endhint -->

--- a/src/content/assertions/f.md
+++ b/src/content/assertions/f.md
@@ -23,7 +23,6 @@ For example, the below code is how the `click()` action is implemented:
 function click(selector) {
   return scoped(selector)
   // perform clickable validation
-    .assert.focusable()
     .assert.not.disabled()
     .assert.f('Failed to click %s: %e')
   // invoke the native DOM method
@@ -33,8 +32,5 @@ function click(selector) {
 }
 ```
 
-In the example above, the thrown error message might be one of the following
-possible messages:
-
-- `Failed to click "button": disabled`
-- `Failed to click CustomInteractor: not focusable, tabindex must be greater than -1`
+In the example above, the thrown error message might look like:<br/>
+`Failed to click "button": is disabled`.


### PR DESCRIPTION
## Purpose

Update API docs for #4

## Approach

Remove mention of focusable assertion from click action docs and from the assert format docs where the click action source is used as an example.