### PR TITLE
Decorator getters

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,9 +11,11 @@
       }
     }],
     ["@babel/proposal-decorators", {
-      "decoratorsBeforeExport": true
+      "legacy": true
     }],
-    "@babel/proposal-class-properties",
+    ["@babel/proposal-class-properties", {
+      "loose": true
+    }],
     "istanbul"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Auto-defined assertions based on user-defined computed getter properties
+
 ### Fixed
 
 - Assigning to getters using the legacy decorator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Assigning to getters using the legacy decorator
+
 ## [1.2.0] - 2019-04-10
 
 ### Changed

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -2,6 +2,7 @@ import from from './utils/from';
 
 const {
   assign,
+  entries,
   getOwnPropertyDescriptors
 } = Object;
 
@@ -39,9 +40,14 @@ export default function interactor(classDescriptor) {
 
     // make a pojo for `from`
     return from.call(constructor, assign(
-      // own properties
-      new constructor(),
-      // prototype properties
+      // get own property initializers
+      entries(getOwnPropertyDescriptors(new constructor()))
+        .reduce((acc, [key, descr]) => {
+          return ('value' in descr && descr.enumerable)
+            ? assign(acc, { [key]: descr.value })
+            : acc;
+        }, {}),
+      // prototype properties (omitting the constructor)
       omit(getOwnPropertyDescriptors(constructor.prototype), 'constructor'),
       // static properties (name is usually non-enumerable)
       { static: assign({ name: constructor.name }, constructor) }

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -30,6 +30,10 @@ describe('Interactor assertions', () => {
         expect(pass).toBe(true);
       }
     };
+
+    get computed() {
+      return 'hello world';
+    }
   }
 
   beforeEach(() => {
@@ -49,16 +53,25 @@ describe('Interactor assertions', () => {
     expect(instance.assert).toHaveProperty('throws', expect.any(Function));
   });
 
+  it('has computed property assertions', () => {
+    expect(instance.assert).toHaveProperty('computed', expect.any(Function));
+  });
+
   describe('making assertions', () => {
     it('resolves when passing', async () => {
       await expect(instance.assert(() => expect(pass).toBeNull()))
         .resolves.toBeUndefined();
+
       pass = true;
       await expect(instance.assert.passing()).resolves.toBeUndefined();
       await expect(instance.assert.finished()).resolves.toBeUndefined();
+
       pass = false;
       await expect(instance.assert.failing()).resolves.toBeUndefined();
       await expect(instance.assert.finished()).resolves.toBeUndefined();
+
+      await expect(instance.assert.computed('hello world'))
+        .resolves.toBeUndefined();
     });
 
     it('rejects when failing', async () => {
@@ -66,6 +79,8 @@ describe('Interactor assertions', () => {
         .rejects.toThrow('expect(received).not.toBeNull()');
       await expect(instance.assert.passing()).rejects.toThrow('`passing` returned false');
       await expect(instance.assert.failing()).rejects.toThrow('`failing` returned false');
+      await expect(instance.assert.computed(20))
+        .rejects.toThrow('`computed` is "hello world" but expected 20');
     });
 
     it('rejects with a custom message when specified', async () => {


### PR DESCRIPTION
## Purpose

Using legacy decorators and having custom computed getter properties caused an error about assigning to getters without setters. This was bubbling from the legacy decorator hook assigning descriptors to an instance of the custom class.

While thinking about custom computed getter properties, it would be helpful to automatically define assertions based on those properties in addition to the auto-defined assertions created when using built-in property creators.

## Approach

In the legacy decorator, instead of assigning properties to an instance of the constructor, initializers are collected from own, enumerable properties of the instance, and prototype properties are assigned to that collection.

For auto-defined assertions for computed getter properties, the getter descriptors are allowed to pass through to the logic responsible for auto-defining other assertions. In the case when a getter does not already have a matcher, a default matcher is created based on the name of the getter property.