### PR TITLE
Fix assert error message fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Assert error message fallback to defaultScope when no specific scope
+
 ## [1.3.0] - 2019-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.3.1] - 2019-05-23
+
 ### Fixed
 
 - Assert error message fallback to defaultScope when no specific scope

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -11,13 +11,16 @@ const {
 
 function getScopeName(interactor) {
   let { scope, parent, detached } = get(interactor);
+  let { defaultScope, name } = interactor.constructor;
 
-  if (typeof scope === 'string') {
-    return `"${scope}"`;
-  } else if (scope == null && parent && !detached) {
+  if (scope == null && parent && !detached) {
     return getScopeName(parent);
+  } else if (typeof scope === 'string') {
+    return `"${scope}"`;
+  } else if (typeof defaultScope === 'string') {
+    return `"${defaultScope}"`;
   } else {
-    return interactor.constructor.name;
+    return name;
   }
 }
 

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -130,7 +130,8 @@ describe('Interactor assertions', () => {
 
     it('has a default error message when nothing is returned', async () => {
       pass = true;
-      await expect(instance.assert.not.throws()).rejects.toThrow('`throws` did not throw an error');
+      await expect(instance.assert.not.throws())
+        .rejects.toThrow('`throws` did not throw an error');
     });
   });
 
@@ -200,6 +201,18 @@ describe('Interactor assertions', () => {
           .assert.validate()
           .assert.passing()
       ).rejects.toThrow('CustomInteractor assertion failed: `passing` returned false');
+    });
+
+    it('uses a specified scope', async () => {
+      instance = new CustomInteractor('#scoped').timeout(50);
+      await expect(instance.assert.passing())
+        .rejects.toThrow('"#scoped" assertion failed');
+    });
+
+    it('uses a default scope with no specified scoped', async () => {
+      CustomInteractor.defaultScope = '#default';
+      await expect(instance.assert.passing())
+        .rejects.toThrow('"#default" assertion failed');
     });
   });
 


### PR DESCRIPTION
## Purpose

When a `defaultScope` is provided, assertion error message formats should fallback to it when no specific scope is used with the constructor.

## Approach

If the interactor isn't referencing a parent and still has no scope, return the `defaultScope` of the constructor before returning the constructor name.

Release v1.3.1