### PR TITLE
Add GitHub link

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "react-icons": "^3.5.0",
+    "react-icons": "^3.7.0",
     "react-instantsearch-dom": "^5.4.0",
     "react-typography": "^0.16.19",
     "rehype-react": "^3.1.0",

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -41,7 +41,7 @@ Icon.propTypes = {
   name: PropTypes.string.isRequired
 };
 
-export default function Icon({ name }) {
-  let MdIcon = Icons[name] || MdHelpOutline;
-  return <MdIcon/>;
+export default function Icon({ name, ...props }) {
+  let Icon = Icons[name] || MdHelpOutline;
+  return <Icon {...props} />;
 }

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -16,34 +16,32 @@ import {
   MdMenu
 } from 'react-icons/md';
 
-const MdIcons = {
-  MdChevronRight,
-  MdExpandMore,
-  MdHelpOutline,
-  MdInfo,
-  MdError,
-  MdWarning,
-  MdDanger: MdError,
-  MdToc,
-  MdSearch,
-  MdArrowBack,
-  MdArrowForward,
-  MdClear,
-  MdMenu
-};
+import {
+  FaGithub
+} from 'react-icons/fa';
 
-function camelize(string) {
-  return string
-    .replace(/(?:^\w|[A-Z]|\b\w)/g, w => w.toUpperCase())
-    .replace(/\s+|-/g, '');
-}
+const Icons = {
+  'chevron-right': MdChevronRight,
+  'expand-more': MdExpandMore,
+  'help-outline': MdHelpOutline,
+  'info': MdInfo,
+  'error': MdError,
+  'warning': MdWarning,
+  'danger': MdError,
+  'toc': MdToc,
+  'search': MdSearch,
+  'arrow-back': MdArrowBack,
+  'arrow-forward': MdArrowForward,
+  'clear': MdClear,
+  'menu': MdMenu,
+  'github': FaGithub
+};
 
 Icon.propTypes = {
   name: PropTypes.string.isRequired
 };
 
 export default function Icon({ name }) {
-  let iconName = camelize(`md-${name}`);
-  let MdIcon = MdIcons[iconName] || MdHelpOutline;
+  let MdIcon = Icons[name] || MdHelpOutline;
   return <MdIcon/>;
 }

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -131,7 +131,7 @@ export default function Sidebar({ location, open, onClose }) {
                 className={style.link}
                 target="blank"
               >
-                <Icon name="github" />
+                <Icon name="github" title="GitHub" />
               </a>
             </div>
           </aside>

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -125,6 +125,14 @@ export default function Sidebar({ location, open, onClose }) {
                   </ul>
                 </Fragment>
               ))}
+
+              <a
+                href="https://github.com/wwilsman/interactor.js"
+                className={style.link}
+                target="blank"
+              >
+                <Icon name="github" />
+              </a>
             </div>
           </aside>
 

--- a/src/components/sidebar/sidebar.module.css
+++ b/src/components/sidebar/sidebar.module.css
@@ -53,7 +53,7 @@
     }
   }
 
-  a {
+  li > a {
     display: block;
     padding: 0.3rem 1rem;
     text-decoration: none;
@@ -96,6 +96,18 @@
     padding: 0.4rem 1.125rem;
     font-weight: 400;
     color: #AAAAAB;
+  }
+
+  .link {
+    color: inherit;
+    display: inline-flex;
+    margin: 0.625rem;
+    padding: 0.5rem;
+    font-size: 1.25rem;
+
+    &:hover {
+      color: black;
+    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8802,10 +8802,12 @@ react-hot-loader@^4.6.2:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
-react-icons@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.5.0.tgz#a6135480e3bcbc63f5dd045193ef2a814263d8d1"
-  integrity sha512-LuKUcavgPWjPrRkIdNbsGw8LqcnhfNN0AGCtU4Td1UkOenJSIWbYppSJrD6zi/TDZOHtTs9opu6ZKB/NFWk21g==
+react-icons@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.7.0.tgz#64fe46231fabfeea27895edeae6c3b78114b8c8f"
+  integrity sha512-7MyPwjIhuyW0D2N3s4DEd0hGPGFf0sK+IIRKhc1FvSpZNVmnUoGvHbmAwzGJU+3my+fvihVWgwU5SDtlAri56Q==
+  dependencies:
+    camelcase "^5.0.0"
 
 react-instantsearch-core@^5.4.0:
   version "5.4.0"


### PR DESCRIPTION
## Purpose

Need to link back to the Github repo for issues and for the curious.

## Approach

Adds a Github icon to the sidebar that links to the repo. Icon component internals were updated to allow icons from multiple icon packs and pass along props such as `title`.