### PR TITLE
Fixes and updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,11 @@ jobs:
       - *attach_workspace
       - run:
           name: Run tests
-          command: yarn test
+          command: yarn test --coverage --junit
+      - store_test_results:
+          path: ./junit
+      - store_artifacts:
+          path: ./junit
 
   deploy:
     <<: *defaults

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /coverage
 *.log
 /.gtm/
+/junit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Ability to provide a custom matcher function to computed property assertions
 - Ability for computed property assertions to assert truthyness when no
   arguments are provided
+- Displaying computed selectors in assertion errors
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   arguments are provided
 - Ability for computed property assertions to accept regular expressions
 - Displaying computed selectors in assertion errors
+- `checked` property and property creator
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Ability to provide a custom matcher function to computed property assertions
+
 ### Fixed
 
 - Undefined or null properties causing errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Ability for computed property assertions to accept regular expressions
 - Displaying computed selectors in assertion errors
 - `checked` property and property creator
+- `selected` property and property creator
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Ability to provide a custom matcher function to computed property assertions
 - Ability for computed property assertions to assert truthyness when no
   arguments are provided
+- Ability for computed property assertions to accept regular expressions
 - Displaying computed selectors in assertion errors
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Undefined or null properties causing errors
 - `assert.not` assertions resolving when an element does not exist
 - `$element` argument being eagerly computed
 - Non-enumerable static properties not being carried over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- `$element` argument being eagerly computed
 - Non-enumerable static properties not being carried over
 - Incorrect parent class when extending from custom interactors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- `assert.not` assertions resolving when an element does not exist
 - `$element` argument being eagerly computed
 - Non-enumerable static properties not being carried over
 - Incorrect parent class when extending from custom interactors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Incorrect parent class when extending from custom interactors
+
 ## [1.3.1] - 2019-05-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.4.0] - 2019-06-09
+
 ### Added
 
 - Ability to provide a custom matcher function to computed property assertions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - Ability to provide a custom matcher function to computed property assertions
+- Ability for computed property assertions to assert truthyness when no
+  arguments are provided
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Non-enumerable static properties not being carried over
 - Incorrect parent class when extending from custom interactors
 
 ## [1.3.1] - 2019-05-23

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,13 @@
 module.exports = (config) => {
   config.set({
     frameworks: ['mocha'],
-    reporters: ['mocha', 'coverage'],
     browsers: ['ChromeHeadless'],
+
+    reporters: [
+      'mocha',
+      'coverage',
+      config.junit && 'junit'
+    ].filter(Boolean),
 
     files: [
       { pattern: 'tests/index.js', watched: false }
@@ -19,7 +24,27 @@ module.exports = (config) => {
     coverageReporter: {
       type: config.coverage === true
         ? 'text-summary'
-        : (config.coverage || 'none')
+        : (config.coverage || 'none'),
+      check: config.converage ? {
+        global: {
+          statements: 100,
+          lines: 100,
+          functions: 100,
+          branches: 100
+        }
+      } : undefined,
+      watermarks: {
+        statements: [100, 100],
+        functions: [100, 100],
+        branches: [100, 100],
+        lines: [100, 100]
+      }
+    },
+
+    junitReporter: {
+      outputDir: './junit',
+      outputFile: 'test-results.xml',
+      useBrowserName: false
     },
 
     webpack: {
@@ -41,6 +66,7 @@ module.exports = (config) => {
     plugins: [
       'karma-chrome-launcher',
       'karma-coverage',
+      'karma-junit-reporter',
       'karma-mocha',
       'karma-mocha-reporter',
       'karma-webpack'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",
+    "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^3.0.5",

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import disabled from './properties/disabled';
 import exists from './properties/exists';
 import focusable from './properties/focusable';
 import focused from './properties/focused';
+import selected from './properties/selected';
 import scrollable, { scrollableX, scrollableY } from './properties/scrollable';
 import text from './properties/text';
 import value from './properties/value';
@@ -63,6 +64,7 @@ const builtIn = toInteractorProperties({
     exists,
     focusable,
     focused,
+    selected,
     scrollable,
     scrollableX,
     scrollableY,
@@ -131,6 +133,7 @@ export {
   exists,
   focusable,
   focused,
+  selected,
   scrollable,
   scrollableX,
   scrollableY,

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import createAsserts from './utils/assert';
 import meta, { set } from './utils/meta';
 
 // property creators
+import checked from './properties/checked';
 import disabled from './properties/disabled';
 import exists from './properties/exists';
 import focusable from './properties/focusable';
@@ -57,6 +58,7 @@ defineProperties(Interactor, {
 const builtIn = toInteractorProperties({
   // properties
   ...(entries({
+    checked,
     disabled,
     exists,
     focusable,
@@ -124,6 +126,7 @@ export {
   Interactor,
   from,
   // property creators
+  checked,
   disabled,
   exists,
   focusable,

--- a/src/properties/checked.js
+++ b/src/properties/checked.js
@@ -1,0 +1,14 @@
+import computed from '../helpers/computed';
+
+export default function checked(selector) {
+  return computed(
+    selector,
+    element => element.checked,
+    actual => ({
+      result: actual,
+      message: () => (
+        `%s ${actual ? 'is' : 'is not'} checked`
+      )
+    })
+  );
+}

--- a/src/properties/selected.js
+++ b/src/properties/selected.js
@@ -1,0 +1,14 @@
+import computed from '../helpers/computed';
+
+export default function selected(selector) {
+  return computed(
+    selector,
+    element => element.selected,
+    actual => ({
+      result: actual,
+      message: () => (
+        `%s ${actual ? 'is' : 'is not'} selected`
+      )
+    })
+  );
+}

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -56,7 +56,7 @@ function validate(interactor) {
       try {
         result = validate.apply(ctx, args);
       } catch (e) {
-        result = false;
+        result = !!e[meta] && !expected;
         message = () => e.message;
       }
 

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -15,7 +15,11 @@ function getScopeName(interactor) {
 
   if (scope == null && parent && !detached) {
     return getScopeName(parent);
-  } else if (typeof scope === 'string') {
+  } else if (typeof scope === 'function') {
+    scope = scope();
+  }
+
+  if (typeof scope === 'string') {
     return `"${scope}"`;
   } else if (typeof defaultScope === 'string') {
     return `"${defaultScope}"`;

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,3 +1,5 @@
+import error from './error';
+
 function isElement(obj) {
   // safe way to check `instanceof Element` when Element can be in a virtual DOM
   return obj && 'ownerDocument' in obj && 'defaultView' in obj.ownerDocument &&
@@ -9,7 +11,7 @@ export function $(selector, $ctx) {
 
   /* istanbul ignore if: sanity check */
   if (!$ctx || typeof $ctx.querySelector !== 'function') {
-    throw new Error('unable to use the current context');
+    throw error('unable to use the current context');
   }
 
   /* istanbul ignore else: unnecessary */
@@ -17,7 +19,7 @@ export function $(selector, $ctx) {
     try {
       $node = $ctx.querySelector(selector);
     } catch (e) {
-      throw new SyntaxError(`"${selector}" is not a valid selector`);
+      throw error(`"${selector}" is not a valid selector`, SyntaxError);
     }
 
   // if an element was given, return it
@@ -30,7 +32,7 @@ export function $(selector, $ctx) {
   }
 
   if (!$node) {
-    throw new Error(`unable to find "${selector}"`);
+    throw error(`unable to find "${selector}"`);
   }
 
   return $node;
@@ -41,7 +43,7 @@ export function $$(selector, $ctx) {
 
   /* istanbul ignore if: sanity check */
   if (!$ctx || typeof $ctx.querySelectorAll !== 'function') {
-    throw new Error('unable to use the current context');
+    throw error('unable to use the current context');
   }
 
   /* istanbul ignore else: unnecessary */
@@ -49,7 +51,7 @@ export function $$(selector, $ctx) {
     try {
       nodes = [].slice.call($ctx.querySelectorAll(selector));
     } catch (e) {
-      throw new SyntaxError(`"${selector}" is not a valid selector`);
+      throw error(`"${selector}" is not a valid selector`, SyntaxError);
     }
 
   // given an iterable, assume it contains nodes

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,0 +1,8 @@
+import meta from './meta';
+
+const { assign } = Object;
+
+// adds meta to an error so it bubbles through negated asseritons
+export default function error(message, Klass = Error) {
+  return assign(new Klass(message), { [meta]: true });
+}

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -203,16 +203,21 @@ export default function from(properties) {
   // define static properties
   defineProperties(
     CustomInteractor,
-    getOwnPropertyDescriptors(staticProps)
+    entries(staticProps).reduce((acc, [name, value]) => {
+      value = !isPropertyDescriptor(value) ? { value } : value;
+      return assign(acc, { [name]: value });
+    }, {})
   );
 
   // define assertions
   defineProperties(CustomInteractor.prototype, {
     assert: {
-      value: createAsserts({
-        ...props.assertions,
-        ...assertions
-      })
+      value: createAsserts(assign(
+        props.assertions,
+        isPropertyDescriptor(assertions)
+          ? assertions.value
+          : assertions
+      ))
     }
   });
 

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -169,7 +169,7 @@ export function toInteractorProperties(properties) {
     descr = 'value' in descr ? descr.value : descr;
 
     // check for attached assertions or computed getters
-    if (descr[meta] || (isPropertyDescriptor(descr) && 'get' in descr)) {
+    if ((descr && descr[meta]) || (isPropertyDescriptor(descr) && 'get' in descr)) {
       let assertion = toInteractorAssertion(key, descr);
       if (assertion) assign(props.assertions, { [key]: assertion });
       if (!isInteractor(descr)) delete descr[meta];

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -1,4 +1,3 @@
-import Interactor from '../interactor';
 import scoped from '../helpers/scoped';
 import count from '../assertions/count';
 import isInteractor from './is-interactor';
@@ -193,11 +192,7 @@ export default function from(properties) {
   } = properties;
 
   let props = toInteractorProperties(ownProps);
-  let Parent = this.prototype instanceof Interactor
-    ? this.prototype.constructor
-    : Interactor;
-
-  class CustomInteractor extends Parent {};
+  class CustomInteractor extends this {};
 
   // define properties from descriptors
   defineProperties(

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -133,7 +133,15 @@ function toInteractorAssertion(name, from) {
     if (!matcher) {
       matcher = (...args) => {
         let [actual, expected] = args;
-        let result = args.length === 1 ? !!actual : actual === expected;
+        let result = !!actual;
+
+        if (args.length > 1) {
+          if (typeof actual === 'string' && expected instanceof RegExp) {
+            result = expected.test(actual);
+          } else {
+            result = actual === expected;
+          }
+        }
 
         return {
           result,

--- a/src/utils/run.js
+++ b/src/utils/run.js
@@ -28,9 +28,11 @@ export function runAssertion(context, subject, stats) {
   context = subject.ctx || context;
 
   let timeout = stats.timeout - getElapsedSince(stats.start, stats.timeout);
-  let arg = subject.assertion.length ? context.$element : undefined;
-  let assertion = subject.assertion.bind(context, arg);
   let converge = subject.always ? always : when;
+
+  let assertion = subject.assertion.length
+    ? () => subject.assertion.call(context, context.$element)
+    : subject.assertion.bind(context);
 
   // always defaults to one-tenth or the remaining timeout
   if (subject.always) {
@@ -52,8 +54,9 @@ export function runCallback(context, subject, stats) {
   context = subject.ctx || context;
 
   let start = now();
-  let arg = subject.callback.length ? context.$element : undefined;
-  let result = subject.callback.call(context, arg);
+  let result = subject.callback.length
+    ? subject.callback.call(context, context.$element)
+    : subject.callback.call(context);
 
   let collectExecStats = value => {
     return collectStats(stats, {

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -34,6 +34,10 @@ describe('Interactor assertions', () => {
     get computed() {
       return 'hello world';
     }
+
+    get truthy() {
+      return true;
+    }
   }
 
   beforeEach(() => {
@@ -55,6 +59,7 @@ describe('Interactor assertions', () => {
 
   it('has computed property assertions', () => {
     expect(instance.assert).toHaveProperty('computed', expect.any(Function));
+    expect(instance.assert).toHaveProperty('truthy', expect.any(Function));
   });
 
   describe('making assertions', () => {
@@ -72,6 +77,7 @@ describe('Interactor assertions', () => {
 
       await expect(instance.assert.computed('hello world'))
         .resolves.toBeUndefined();
+      await expect(instance.assert.truthy()).resolves.toBeUndefined();
     });
 
     it('rejects when failing', async () => {
@@ -134,6 +140,8 @@ describe('Interactor assertions', () => {
 
       await expect(instance.assert.not.computed('hello world'))
         .rejects.toThrow('`computed` is "hello world"');
+
+      await expect(instance.assert.not.truthy()).rejects.toThrow('`truthy` is true');
     });
 
     it('rejects with a custom message when specified', async () => {

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -92,6 +92,21 @@ describe('Interactor assertions', () => {
       await expect(instance.assert.even(3)).rejects.toThrow('3 is not even');
     });
 
+    it('accepts a matcher function for computed property assertions', async () => {
+      await expect(instance.assert.computed(str => {
+        return str === 'foobar';
+      })).rejects.toThrow('returned false');
+      await expect(instance.assert.computed(str => {
+        expect(str).toEqual('foobar');
+      })).rejects.toThrow('expect(received).toEqual(expected)');
+      await expect(instance.assert.computed(str => {
+        expect(str).toEqual('hello world');
+      })).resolves.toBeUndefined();
+      await expect(instance.assert.computed(str => {
+        return str === 'hello world';
+      })).resolves.toBeUndefined();
+    });
+
     it('bubbles error messages', async () => {
       await expect(instance.assert.throws()).rejects.toThrow('expect(received).toBe(expected)');
     });

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -107,13 +107,18 @@ describe('Interactor assertions', () => {
       await expect(instance.assert.not.passing()).resolves.toBeUndefined();
       await expect(instance.assert.not.failing()).resolves.toBeUndefined();
       await expect(instance.assert.not.finished()).resolves.toBeUndefined();
+      await expect(instance.assert.not.computed(20)).resolves.toBeUndefined();
     });
 
     it('rejects when failing', async () => {
       pass = true;
       await expect(instance.assert.not.passing()).rejects.toThrow('`passing` returned true');
+
       pass = false;
       await expect(instance.assert.not.failing()).rejects.toThrow('`failing` returned true');
+
+      await expect(instance.assert.not.computed('hello world'))
+        .rejects.toThrow('`computed` is "hello world"');
     });
 
     it('rejects with a custom message when specified', async () => {

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -133,6 +133,15 @@ describe('Interactor assertions', () => {
       await expect(instance.assert.not.throws())
         .rejects.toThrow('`throws` did not throw an error');
     });
+
+    it('always rejects when specific errors occur', async () => {
+      await expect(
+        instance.assert.not.disabled('#not-found')
+      ).rejects.toThrow('unable to find "#not-found"');
+      await expect(
+        instance.assert.not.disabled('!wrong')
+      ).rejects.toThrow('"!wrong" is not a valid selector');
+    });
   });
 
   describe('chaining assertions', () => {

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -32,7 +32,7 @@ describe('Interactor assertions', () => {
     };
 
     get computed() {
-      return 'hello world';
+      return 'Hello World!';
     }
 
     get truthy() {
@@ -75,8 +75,8 @@ describe('Interactor assertions', () => {
       await expect(instance.assert.failing()).resolves.toBeUndefined();
       await expect(instance.assert.finished()).resolves.toBeUndefined();
 
-      await expect(instance.assert.computed('hello world'))
-        .resolves.toBeUndefined();
+      await expect(instance.assert.computed('Hello World!')).resolves.toBeUndefined();
+      await expect(instance.assert.computed(/hello/i)).resolves.toBeUndefined();
       await expect(instance.assert.truthy()).resolves.toBeUndefined();
     });
 
@@ -86,7 +86,9 @@ describe('Interactor assertions', () => {
       await expect(instance.assert.passing()).rejects.toThrow('`passing` returned false');
       await expect(instance.assert.failing()).rejects.toThrow('`failing` returned false');
       await expect(instance.assert.computed(20))
-        .rejects.toThrow('`computed` is "hello world" but expected 20');
+        .rejects.toThrow('`computed` is "Hello World!" but expected 20');
+      await expect(instance.assert.computed(/foo/))
+        .rejects.toThrow('`computed` is "Hello World!" but expected /foo/');
     });
 
     it('rejects with a custom message when specified', async () => {
@@ -106,10 +108,10 @@ describe('Interactor assertions', () => {
         expect(str).toEqual('foobar');
       })).rejects.toThrow('expect(received).toEqual(expected)');
       await expect(instance.assert.computed(str => {
-        expect(str).toEqual('hello world');
+        expect(str).toEqual('Hello World!');
       })).resolves.toBeUndefined();
       await expect(instance.assert.computed(str => {
-        return str === 'hello world';
+        return str === 'Hello World!';
       })).resolves.toBeUndefined();
     });
 
@@ -138,8 +140,8 @@ describe('Interactor assertions', () => {
       pass = false;
       await expect(instance.assert.not.failing()).rejects.toThrow('`failing` returned true');
 
-      await expect(instance.assert.not.computed('hello world'))
-        .rejects.toThrow('`computed` is "hello world"');
+      await expect(instance.assert.not.computed('Hello World!'))
+        .rejects.toThrow('`computed` is "Hello World!"');
 
       await expect(instance.assert.not.truthy()).rejects.toThrow('`truthy` is true');
     });

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -590,6 +590,17 @@ describe('Interactor', () => {
       })).resolves.toBeUndefined();
     });
 
+    it('eventually throws an error when the scoped element cannot be found', async () => {
+      let scoped = new Interactor('#not-found').timeout(50);
+      let now = Date.now();
+
+      await expect(scoped.when($element => {
+        expect($element).toBeDefined();
+      })).rejects.toThrow('unable to find "#not-found"');
+
+      expect(Date.now() - now).toBeGreaterThanOrEqual(50);
+    });
+
     describe('finding elements within the scope', () => {
       it('can find a single DOM element within the scope', () => {
         expect(new Interactor().$('.test-p').innerText).toBe('A');

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -791,6 +791,8 @@ describe('Interactor', () => {
         },
 
         foo: 'bar',
+        undef: undefined,
+        nil: null,
 
         get getter() {
           return 'got';
@@ -819,7 +821,8 @@ describe('Interactor', () => {
 
     it('creates an interactor class with the provided properties', () => {
       expect(TestInteractor.prototype).toHaveProperty('foo', 'bar');
-      expect(TestInteractor.prototype).toHaveProperty('getter', 'got');
+      expect(TestInteractor.prototype).toHaveProperty('undef', undefined);
+      expect(TestInteractor.prototype).toHaveProperty('nil', null);
       expect(TestInteractor.prototype).toHaveProperty('func', expect.any(Function));
     });
 
@@ -881,6 +884,8 @@ describe('Interactor', () => {
         static fn() {}
 
         foo = 'bar';
+        undef = undefined;
+        nil = null;
 
         get getter() {
           return 'got';
@@ -909,6 +914,8 @@ describe('Interactor', () => {
 
     it('extends the interactor class with the provided properties', () => {
       expect(TestInteractor.prototype).toHaveProperty('foo', 'bar');
+      expect(TestInteractor.prototype).toHaveProperty('undef', undefined);
+      expect(TestInteractor.prototype).toHaveProperty('nil', null);
       expect(TestInteractor.prototype).toHaveProperty('getter', 'got');
     });
 

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -773,7 +773,10 @@ describe('Interactor', () => {
       TestInteractor = Interactor.from({
         static: {
           name: 'TestInteractor',
-          defaultScope: '.test'
+          defaultScope: '.test',
+          test: 'hello world',
+          get get() { return this.test; },
+          fn() {}
         },
 
         foo: 'bar',
@@ -798,6 +801,9 @@ describe('Interactor', () => {
     it('uses properties from the `static` key for static members', () => {
       expect(TestInteractor.name).toEqual('TestInteractor');
       expect(TestInteractor.defaultScope).toEqual('.test');
+      expect(TestInteractor.test).toEqual('hello world');
+      expect(TestInteractor.get).toEqual('hello world');
+      expect(TestInteractor.fn).toEqual(expect.any(Function));
     });
 
     it('creates an interactor class with the provided properties', () => {
@@ -859,6 +865,9 @@ describe('Interactor', () => {
     beforeEach(() => {
       TestInteractor = @interactor class TestInteractor {
         static defaultScope = '.test';
+        static test = 'hello world';
+        static get get() { return this.test; }
+        static fn() {}
 
         foo = 'bar';
 
@@ -882,6 +891,9 @@ describe('Interactor', () => {
     it('uses properties from the `static` key for static members', () => {
       expect(TestInteractor.name).toEqual('TestInteractor');
       expect(TestInteractor.defaultScope).toEqual('.test');
+      expect(TestInteractor.test).toEqual('hello world');
+      expect(TestInteractor.get).toEqual('hello world');
+      expect(TestInteractor.fn).toEqual(expect.any(Function));
     });
 
     it('extends the interactor class with the provided properties', () => {

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -819,9 +819,12 @@ describe('Interactor', () => {
     });
 
     it('creates an interactor class from the origin class', () => {
-      let ExtendedInteractor = TestInteractor.from({ bar: 'baz' });
-      expect(ExtendedInteractor.prototype).toHaveProperty('bar', 'baz');
-      expect(ExtendedInteractor.prototype).toBeInstanceOf(TestInteractor);
+      let ExtendedInteractor = TestInteractor.from({
+        bar: { enumerable: false, configurable: false, get: () => 'baz' }
+      });
+
+      expect(new ExtendedInteractor()).toHaveProperty('bar', 'baz');
+      expect(new ExtendedInteractor()).toBeInstanceOf(TestInteractor);
     });
 
     describe('with reserved property names', () => {
@@ -899,9 +902,12 @@ describe('Interactor', () => {
     });
 
     it('extends the interactor class from the origin class', () => {
-      let ExtendedInteractor = @interactor class extends TestInteractor { bar = 'baz' };
-      expect(ExtendedInteractor.prototype).toHaveProperty('bar', 'baz');
-      expect(ExtendedInteractor.prototype).toBeInstanceOf(TestInteractor);
+      @interactor class ExtendedInteractor extends TestInteractor {
+        bar = { enumerable: false, configurable: false, get: () => 'baz' };
+      }
+
+      expect(new ExtendedInteractor()).toHaveProperty('bar', 'baz');
+      expect(new ExtendedInteractor()).toBeInstanceOf(TestInteractor);
     });
 
     describe('with reserved property names', () => {

--- a/tests/helpers/collection.test.js
+++ b/tests/helpers/collection.test.js
@@ -118,6 +118,11 @@ describe('Interactor helpers - collection', () => {
     expect(test.assert.items().count(4)).toBeInstanceOf(CollectionInteractor);
   });
 
+  it('throws scoped assertion errors for computed selectors', async () => {
+    await expect(test.assert.byClassName('a').matches('.b'))
+      .rejects.toThrow('".a" assertion failed');
+  });
+
   it('returns own instances from collection methods after calling #only', () => {
     expect(test.byClassName('a').only()).toBeInstanceOf(ItemInteractor);
     expect(test.byClassName('a').only().click()).toBeInstanceOf(ItemInteractor);

--- a/tests/properties/checked.test.js
+++ b/tests/properties/checked.test.js
@@ -1,0 +1,106 @@
+import expect from 'expect';
+
+import { injectHtml } from '../helpers';
+import interactor, { Interactor, checked } from 'interactor.js';
+
+describe('Interactor properties - checked', () => {
+  beforeEach(() => {
+    injectHtml(`
+      <fieldset>
+        <input type="radio" checked/>
+      </fieldset>
+    `);
+  });
+
+  describe('with the default property', () => {
+    let radio = new Interactor('input').timeout(50);
+
+    it('returns true when the element is checked', () => {
+      expect(radio).toHaveProperty('checked', true);
+    });
+
+    it('returns false when the element is not checked', () => {
+      radio.$element.checked = false;
+      expect(radio).toHaveProperty('checked', false);
+    });
+
+    describe('and the default assertion', () => {
+      let field = new Interactor('fieldset').timeout(50);
+
+      it('resolves when passing', async () => {
+        await expect(radio.assert.checked()).resolves.toBeUndefined();
+        radio.$element.checked = false;
+        await expect(radio.assert.not.checked()).resolves.toBeUndefined();
+      });
+
+      it('resolves when passing with a selector', async () => {
+        await expect(field.assert.checked('input')).resolves.toBeUndefined();
+        radio.$element.checked = false;
+        await expect(field.assert.not.checked('input')).resolves.toBeUndefined();
+      });
+
+      it('rejects with an error when failing', async () => {
+        await expect(radio.assert.not.checked()).rejects.toThrow('is checked');
+        radio.$element.checked = false;
+        await expect(radio.assert.checked()).rejects.toThrow('is not checked');
+      });
+
+      it('rejects with an error when failing with a selector', async () => {
+        await expect(field.assert.not.checked('input')).rejects.toThrow('"input" is checked');
+        radio.$element.checked = false;
+        await expect(field.assert.checked('input')).rejects.toThrow('"input" is not checked');
+      });
+    });
+  });
+
+  describe('with the property creator', () => {
+    @interactor class FieldInteractor {
+      static defaultScope = 'fieldset';
+      checked = checked('input');
+      foo = checked('input');
+    }
+
+    let field = new FieldInteractor().timeout(50);
+
+    it('returns true when the specified element is checked', () => {
+      expect(field).toHaveProperty('checked', true);
+    });
+
+    it('returns false when the specified element is not checked', () => {
+      field.$('input').checked = false;
+      expect(field).toHaveProperty('checked', false);
+    });
+
+    describe('and the default assertion', () => {
+      it('resolves when passing', async () => {
+        await expect(field.assert.checked()).resolves.toBeUndefined();
+        field.$('input').checked = false;
+        await expect(field.assert.not.checked()).resolves.toBeUndefined();
+      });
+
+      it('rejects with an error when failing', async () => {
+        await expect(field.assert.not.checked()).rejects.toThrow('checked');
+        field.$('input').checked = false;
+        await expect(field.assert.checked()).rejects.toThrow('not checked');
+      });
+    });
+
+    describe('and the auto-defined assertion', () => {
+      it('has an auto-defined assertion', () => {
+        expect(field.assert).toHaveProperty('foo', expect.any(Function));
+      });
+
+      it('resolves when passing', async () => {
+        await expect(field.assert.foo()).resolves.toBeUndefined();
+        field.$('input').checked = false;
+        await expect(field.assert.not.foo()).resolves.toBeUndefined();
+      });
+
+      it('rejects with an error when failing', async () => {
+        await expect(field.assert.not.foo()).rejects.toThrow('checked');
+        field.$('input').checked = false;
+        await expect(field.assert.foo()).rejects.toThrow('not checked');
+      });
+    });
+  });
+});

--- a/tests/properties/selected.test.js
+++ b/tests/properties/selected.test.js
@@ -1,0 +1,88 @@
+import expect from 'expect';
+
+import { injectHtml } from '../helpers';
+import interactor, { scoped, collection, selected } from 'interactor.js';
+
+describe('Interactor properties - selected', () => {
+  beforeEach(() => {
+    injectHtml(`
+      <select>
+        <option value="0">First</option>
+        <option value="1" selected>Second</option>
+      </select>
+    `);
+  });
+
+  describe('with the default property', () => {
+    let select = scoped('select', {
+      option: collection('option')
+    }).timeout(50);
+
+    it('returns true when the element is selected', () => {
+      expect(select.option(1)).toHaveProperty('selected', true);
+    });
+
+    it('returns false when the element is not selected', () => {
+      expect(select.option(0)).toHaveProperty('selected', false);
+    });
+
+    describe('and the default assertion', () => {
+      it('resolves when passing', async () => {
+        await expect(select.assert.option(1).selected()).resolves.toBeUndefined();
+        await expect(select.assert.option(0).not.selected()).resolves.toBeUndefined();
+      });
+
+      it('resolves when passing with a selector', async () => {
+        await expect(select.assert.selected('[value="1"]')).resolves.toBeUndefined();
+        await expect(select.assert.not.selected('[value="0"]')).resolves.toBeUndefined();
+      });
+
+      it('rejects with an error when failing', async () => {
+        await expect(select.assert.option(1).not.selected()).rejects.toThrow('is selected');
+        await expect(select.assert.option(0).selected()).rejects.toThrow('is not selected');
+      });
+
+      it('rejects with an error when failing with a selector', async () => {
+        await expect(select.assert.not.selected('[value="1"]'))
+          .rejects.toThrow('"[value="1"]" is selected');
+        await expect(select.assert.selected('[value="0"]'))
+          .rejects.toThrow('"[value="0"]" is not selected');
+      });
+    });
+  });
+
+  describe('with the property creator', () => {
+    @interactor class SelectInteractor {
+      static defaultScope = 'select';
+      first = selected('[value="0"]');
+      second = selected('[value="1"]');
+    }
+
+    let select = new SelectInteractor().timeout(50);
+
+    it('returns true when the specified element is selected', () => {
+      expect(select).toHaveProperty('second', true);
+    });
+
+    it('returns false when the specified element is not selected', () => {
+      expect(select).toHaveProperty('first', false);
+    });
+
+    describe('and the auto-defined assertion', () => {
+      it('has an auto-defined assertion', () => {
+        expect(select.assert).toHaveProperty('first', expect.any(Function));
+        expect(select.assert).toHaveProperty('second', expect.any(Function));
+      });
+
+      it('resolves when passing', async () => {
+        await expect(select.assert.second()).resolves.toBeUndefined();
+        await expect(select.assert.not.first()).resolves.toBeUndefined();
+      });
+
+      it('rejects with an error when failing', async () => {
+        await expect(select.assert.not.second()).rejects.toThrow('selected');
+        await expect(select.assert.first()).rejects.toThrow('not selected');
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,6 +3387,14 @@ karma-coverage@^1.1.2:
     minimatch "^3.0.0"
     source-map "^0.5.1"
 
+karma-junit-reporter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz#4f9c40cedfb1a395f8aef876abf96189917c6396"
+  integrity sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "8.2.2"
+
 karma-mocha-reporter@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz#15120095e8ed819186e47a0b012f3cd741895560"
@@ -5883,6 +5891,11 @@ ws@~3.3.1:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
+
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+  integrity sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
While using interactor, I found several small issues and also thought of a few useful features as well.

### Fixes

- _Fixed incorrect parent class when extend custom interactors_

  The `from` method sometimes assumed that the bound class was not always an interactor. Since it is a static interactor method, the bound class should always be an interactor.

  The decorator sometimes bound a non-interactor to the `from` method. Now that `from` correctly assumes it is _always_ bound to an interactor, the decorator needs to ensure that it _always_ binds an interactor.

- _Fix non-enumerable static properties not being carried over_

  Static getters and methods are non-enumerable and so were not being applied to custom interactor classes. By allowing static property descriptors, we can apply all static property descriptors from a class when creating the custom interactor.

- _Fix `$element` argument being eagerly computed

  When the `$element` argument is given to assertions, and by extension the `when` method, it is eagerly computed during `run` which causes an immediate error when the element is not found. Lazily computing the argument allows assertions and the `when` method to properly rerun until `$element` does not throw an error.

- _Fix negated assertions resolving when the element cannot be found_

  The `not` property sets the expectation for the following assertion to fail; when an "unable to find element" error occurs, the assertion _technically_ fails, which satisfies the `not` expectation.

  Some errors should always bubble through the `not` expectation. These errors can be created with the new `error` util which sets an internal meta value on the error to tell the validator to always raise the error.

- _Fix undefined or null properties causing errors with the decorator_

### Computed assertion features

- Custom matcher functions can now be passed to computed assertions

``` javascript
@interactor class FooInteractor {
  get bar() { return foobar; }
}

new FooInteractor()
  .assert.bar(value => value === foobar)
```

- When no arguments are given to computed assertions, they are compared for truthyness

``` javascript
@interactor class FooInteractor {
  get true() { return true; }
}

new FooInteractor()
  .assert.true()
```

- When a RegExp is passed to a computed assertion that returns a string, the `.test` method is called to determine the assertion result.

``` javascript
@interactor class FooInteractor {
  get greeting() { return 'Hello World!'; }
}

new FooInteractor()
  .assert.greeting(/hello/i)
```

### Other changes

- Computed selectors, such as those used with the `collection` helper, are now evaluated when an assertion error is thrown.

- Added coverage thresholds and junit output to CircleCI

- Added `checked` and `selected` properties and property creators. They work just like `disabled` and return their respective DOM properties but with better assertion errors than using the `property` helper.