### PR TITLE
Fix `from` pojo getters begin evaluated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- `from` POJO getters being evaluated instead of transferred to the custom
+  interactor class
+
 ## [1.4.0] - 2019-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.4.1] - 2019-06-09
+
 ### Fixed
 
 - `from` POJO getters being evaluated instead of transferred to the custom

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/utils/keyboard.js
+++ b/src/utils/keyboard.js
@@ -88,7 +88,6 @@ export function isBackOrDel(key) {
   return key === 'Backspace' || key === 'Delete';
 }
 
-// TODO: implement range and delete
 export function inputText(element, text, options, range) {
   let opts = text ? assign({ charCode: text.charCodeAt(0) }, options) : options;
   let cancelled = !dispatch(element, 'keypress', opts);

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -795,7 +795,7 @@ describe('Interactor', () => {
         nil: null,
 
         get getter() {
-          return 'got';
+          return this.getgot;
         },
 
         func() {},
@@ -804,6 +804,12 @@ describe('Interactor', () => {
           enumerable: false,
           configurable: false,
           value: () => {}
+        },
+
+        getgot: {
+          enumerable: false,
+          configurable: false,
+          get: () => 'got'
         },
 
         nested: new Interactor(),
@@ -823,11 +829,13 @@ describe('Interactor', () => {
       expect(TestInteractor.prototype).toHaveProperty('foo', 'bar');
       expect(TestInteractor.prototype).toHaveProperty('undef', undefined);
       expect(TestInteractor.prototype).toHaveProperty('nil', null);
+      expect(TestInteractor.prototype).toHaveProperty('getter', 'got');
       expect(TestInteractor.prototype).toHaveProperty('func', expect.any(Function));
     });
 
     it('creates an interactor class using property descriptors', () => {
       expect(TestInteractor.prototype).toHaveProperty('descr', expect.any(Function));
+      expect(TestInteractor.prototype).toHaveProperty('getgot', 'got');
     });
 
     it('creates an interactor class with nested interactors', () => {
@@ -888,7 +896,7 @@ describe('Interactor', () => {
         nil = null;
 
         get getter() {
-          return 'got';
+          return this.getgot;
         }
 
         func() {}
@@ -897,6 +905,12 @@ describe('Interactor', () => {
           enumerable: false,
           configurable: false,
           value: () => {}
+        }
+
+        getgot = {
+          enumerable: false,
+          configurable: false,
+          get: () => 'got'
         }
 
         nested = new Interactor();
@@ -917,10 +931,12 @@ describe('Interactor', () => {
       expect(TestInteractor.prototype).toHaveProperty('undef', undefined);
       expect(TestInteractor.prototype).toHaveProperty('nil', null);
       expect(TestInteractor.prototype).toHaveProperty('getter', 'got');
+      expect(TestInteractor.prototype).toHaveProperty('func', expect.any(Function));
     });
 
     it('extends the interactor class using property descriptors', () => {
       expect(TestInteractor.prototype).toHaveProperty('test', expect.any(Function));
+      expect(TestInteractor.prototype).toHaveProperty('getgot', 'got');
     });
 
     it('extends the interactor class with nested interactors', () => {


### PR DESCRIPTION
## Purpose

This fix was dropped while packaging up #10.

When using getters in POJOs, they were either being evaluated or referenced the wrong context with `this`.

## Approach

Resist spreading properties in the `from` util. This has the effect of invoking getters or leaving the getter's context to refer to the incoming object.

By not spreading and resting, we can prevent this until `getOwnPropertyDescriptors` comes into play to collect properties.

**Releases v1.4.1**