### PR TITLE
Fix links

### DIFF
--- a/src/content/actions/keydown.md
+++ b/src/content/actions/keydown.md
@@ -21,7 +21,7 @@ instance of the interactor with the action added to it's queue.
 After a key is pressed, subsequent calls with the same key will have `repeat`
 set to true. If a key is a modifier key such as `Shift`, `Meta`, `Control`, or
 `Alt`, subsequent keys will be sent with that modifier. To release the modifier
-key, use [`keyup`](actions/keyup).
+key, use [`keyup`](/actions/keyup).
 
 The `range` option can be provided to insert characters at an index, or
 remove/replace characters between indices.

--- a/src/content/custom-interactors.md
+++ b/src/content/custom-interactors.md
@@ -79,8 +79,8 @@ describe('logging in', () => {
 ```
 <!-- endtabbed -->
 
-Built-in property creators can be found [here](/properties/), and built-in
-actions can be found [here](/actions/).
+Built-in property creators can be found [here](/properties), and built-in
+actions can be found [here](/actions).
 
 <!-- hint: info -->
 It's **highly** recommended that you build custom component interactors for unit
@@ -90,7 +90,7 @@ acceptance tests.
 
 ## Custom assertions
 
-Custom properties created using the [built-in property creators](/properties/)
+Custom properties created using the [built-in property creators](/properties)
 automatically create custom assertions as well.
 
 In the example above, we defined a few custom interactor properties for the
@@ -260,7 +260,7 @@ const LoginInteractor = Interactor.from({
 ```
 
 New interactor instances can also be created using a static `scoped` method, or
-by passing an custom interactor class to the [`scoped`](helpers/scoped)
+by passing an custom interactor class to the [`scoped`](/helpers/scoped)
 helper.
 
 ``` javascript

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -15,7 +15,7 @@ component or application. Instead of calling methods and expecting side effects,
 interactors work on the premise that a user will interact with your components
 or application and expect feedback from those interactions.
 
-[Getting Started](getting-started)
+[Getting Started](/getting-started)
 
 Interactor.js provides several common actions out of the box and makes it a
 breeze to define your own custom actions. Actions return interactors, which
@@ -23,7 +23,7 @@ automatically run when using `await`. You can chain additional actions together
 to create more complex actions, and since interactors are lazy and immutable,
 you can save and reuse those complex actions throughout your tests.
 
-[Using Actions](using-actions)
+[Using Actions](/using-actions)
 
 The real power of interactors comes from the ability to define custom
 interactors and compose those custom interactors together using a page-object
@@ -31,4 +31,4 @@ pattern. Custom interactors can be written for unit testing common components,
 and those interactors can then be used to build page interactors for acceptance
 testing applications.
 
-[Custom Interactors](custom-interactor)
+[Custom Interactors](/custom-interactors)

--- a/src/content/making-assertions.md
+++ b/src/content/making-assertions.md
@@ -22,7 +22,7 @@ it('is a disabled card component', async () => {
 });
 ```
 
-Built-in assertions can be found [here](assertions).
+Built-in assertions can be found [here](/assertions).
 
 ## Negating assertions
 

--- a/src/content/using-actions.md
+++ b/src/content/using-actions.md
@@ -17,7 +17,7 @@ await focus('.password').type('CorrectHorseBatteryStaple').blur();
 await click('.submit').timeout(500);
 ```
 
-Built-in actions that ship with interactor.js can be found [here](actions/index).
+Built-in actions that ship with interactor.js can be found [here](/actions).
 
 <!-- hint: danger -->
 Actions return interactors, and each interactor has it's own timeout. Always
@@ -29,7 +29,7 @@ succinct.
 ## Custom actions
 
 Creating custom actions is as easy as returning interactors from your own
-functions. A [`scoped()`](helpers/scoped) helper is even provided if you
+functions. A [`scoped()`](/helpers/scoped) helper is even provided if you
 prefer not to use the new keyword inside of custom actions.
 
 ``` javascript

--- a/src/content/using-interactors.md
+++ b/src/content/using-interactors.md
@@ -55,7 +55,7 @@ await new Interactor('.signup-form')
 Other actions have their own built-in validations, such as `focus()` ensuring
 that the element is focusable, and `blur()` ensuring that the element first has
 focus. To see which validations occur for an action, check out each actions
-corresponding [API section](actions/index).
+corresponding [API section](/actions).
 
 ## Reading DOM state
 


### PR DESCRIPTION
Some links were broken mostly due to missing a leading `/`.

A link on the home page was also missing a trailing `s`.

Also removed some trailing `/` and unnecessary `/index` as well.