### PR TITLE
Export computed helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.4.2] - 2019-06-24
+
 ### Fixed
 
 - Export `computed` helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Export `computed` helper
+
 ## [1.4.1] - 2019-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,7 @@ export { default as count } from './properties/count';
 export { default as property } from './properties/property';
 export { default as matches } from './properties/matches';
 export { default as collection } from './helpers/collection';
+export { default as computed } from './helpers/computed';
 export { default as isInteractor } from './utils/is-interactor';
 export { when, always } from './helpers/converge';
 export { default } from './decorator';


### PR DESCRIPTION
The `computed` helper was never exported publicly. There are no tests that test the `computed` helper directly since all other properties use it and have tests themselves. No tests have been added since it would incite needing to test every export.

This releases v1.4.2