### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Collection count assertion not returning topmost parent
+- Ability to define assertions with matching built-in names
 
 ## [1.4.2] - 2019-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Collection count assertion not returning topmost parent
+
 ## [1.4.2] - 2019-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Collection count assertion not returning topmost parent
 - Ability to define assertions with matching built-in names
+- `check` and `uncheck` actions not sending click event
+- `uncheck` working with radio buttons
 
 ## [1.4.2] - 2019-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Ability to define assertions with matching built-in names
 - `check` and `uncheck` actions not sending click event
 - `uncheck` working with radio buttons
+- `assert` should be top-level only
 
 ## [1.4.2] - 2019-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.4.3] - 2019-06-25
+
 ### Fixed
 
 - Collection count assertion not returning topmost parent

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/actions/check.js
+++ b/src/actions/check.js
@@ -1,34 +1,37 @@
 import scoped from '../helpers/scoped';
-import dispatch from '../utils/dispatch';
 
 function isCheckboxOrRadio(element) {
-  if (element.tagName.toLowerCase() !== 'input') {
-    throw new Error('not an input element');
-  } else if (element.type !== 'checkbox' && element.type !== 'radio') {
+  if (element.type !== 'checkbox' && element.type !== 'radio') {
     throw new Error('not a checkbox or radio button');
-  } else if (element.disabled) {
-    throw new Error('disabled');
+  }
+}
+
+function isCheckboxNotRadio(element) {
+  if (element.type === 'radio') {
+    throw new Error('radio buttons cannot be unchecked');
+  } else if (element.type !== 'checkbox') {
+    throw new Error('not a checkbox');
   }
 }
 
 export function uncheck(selector) {
   return scoped(selector)
-    .assert(isCheckboxOrRadio)
+    .assert(isCheckboxNotRadio)
+    .assert.not.disabled()
+    .assert.checked()
     .assert.f('Failed to uncheck %s: %e')
     .do(element => {
-      element.checked = false;
-      dispatch(element, 'input', { cancelable: false });
-      dispatch(element, 'change', { cancelable: false });
+      element.click();
     });
 }
 
 export default function check(selector) {
   return scoped(selector)
     .assert(isCheckboxOrRadio)
+    .assert.not.disabled()
+    .assert.not.checked()
     .assert.f('Failed to check %s: %e')
     .do(element => {
-      element.checked = true;
-      dispatch(element, 'input', { cancelable: false });
-      dispatch(element, 'change', { cancelable: false });
+      element.click();
     });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import Interactor from './interactor';
 import from, { toInteractorProperties } from './utils/from';
-import createAsserts from './utils/assert';
+import createAsserts, { getAssertFor } from './utils/assert';
+import { chainAssert } from './utils/chainable';
 import meta, { set } from './utils/meta';
 
 // property creators
@@ -114,10 +115,8 @@ defineProperties(Interactor.prototype, {
       // defined here to avoid circular imports
       scoped: {
         value(...args) {
-          return set(scoped(...args), {
-            parent: this[meta],
-            chain: true
-          }).assert;
+          let next = set(scoped(...args), { parent: this[meta] });
+          return chainAssert(getAssertFor(next));
         }
       }
     })

--- a/src/interactor.js
+++ b/src/interactor.js
@@ -71,17 +71,17 @@ export default class Interactor {
       })
     });
 
-    // build assert object for this instance
-    defineProperty(this, 'assert', {
-      enumerable: false,
-      configurable: true,
-      value: getAssertFor(this)
-    });
-
-    // given a parent, make all methods and getters return
-    // parent-chainable instances of themselves
     if (parent && chain) {
+      // given a parent, make all methods and getters return
+      // parent-chainable instances of themselves
       makeChainable(this);
+    } else {
+      // build assert object for top level instances
+      defineProperty(this, 'assert', {
+        enumerable: false,
+        configurable: true,
+        value: getAssertFor(this)
+      });
     }
   }
 

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -133,8 +133,12 @@ export function getAssertFor(interactor) {
   let { [meta]: proto, ...assertions } = getAllAssertions(interactor);
 
   return defineProperties(
-    assign(assert.bind(interactor), assertions, { [meta]: interactor }),
-    assign({}, proto, getOwnPropertyDescriptors(assertProto))
+    assert.bind(interactor),
+    entries(assertions).reduce((props, [name, value]) => assign({
+      [name]: { value, configurable: true }
+    }, props), assign({
+      [meta]: { value: interactor }
+    }, proto, getOwnPropertyDescriptors(assertProto)))
   );
 }
 

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -1,4 +1,5 @@
 import meta, { get, set } from './meta';
+import { chainAssert } from './chainable';
 
 const {
   assign,
@@ -109,9 +110,8 @@ function assert(assertion) {
 
 const assertProto = {
   get not() {
-    let next = set(this[meta], 'assert', { expected: false });
-    next = set(next, { chain: !!get(next, 'parent') });
-    return next.assert;
+    let assert = getAssertFor(set(this[meta], 'assert', { expected: false }));
+    return get(this[meta], 'parent') ? chainAssert(assert) : assert;
   },
 
   f(format) {

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -98,7 +98,8 @@ function toInteractorAssertion(name, from) {
       value(...args) {
         // given no arguments, return a single assertion method
         if (!args.length) {
-          let ctx = this[meta];
+          let parent = get(this[meta], 'parent');
+          let ctx = set(this[meta], { chain: !!parent });
 
           let validate = function(expected) {
             return count.call(this, scope.call(this), expected);
@@ -110,10 +111,11 @@ function toInteractorAssertion(name, from) {
               return assert;
             },
 
-            count: (...args) => {
+            count(...args) {
               let { validations, expected } = get(ctx, 'assert');
               validations = validations.concat({ args, expected, validate });
-              return set(ctx, 'assert', { validations, expected: true });
+              ctx = set(ctx, 'assert', { validations, expected: true });
+              return parent ? parent.append(ctx) : ctx;
             }
           };
 

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -28,7 +28,10 @@ describe('Interactor assertions', () => {
 
       throws: () => {
         expect(pass).toBe(true);
-      }
+      },
+
+      name: () => true,
+      length: () => true
     };
 
     get computed() {
@@ -60,6 +63,11 @@ describe('Interactor assertions', () => {
   it('has computed property assertions', () => {
     expect(instance.assert).toHaveProperty('computed', expect.any(Function));
     expect(instance.assert).toHaveProperty('truthy', expect.any(Function));
+  });
+
+  it('has assertions with built-in names', () => {
+    expect(instance.assert).toHaveProperty('name', expect.any(Function));
+    expect(instance.assert).toHaveProperty('length', expect.any(Function));
   });
 
   describe('making assertions', () => {

--- a/tests/core/assert.test.js
+++ b/tests/core/assert.test.js
@@ -70,6 +70,20 @@ describe('Interactor assertions', () => {
     expect(instance.assert).toHaveProperty('length', expect.any(Function));
   });
 
+  it('cannot use nested assertions without .only()', async () => {
+    @interactor class NestedInteractor { nested = instance }
+    let test = new NestedInteractor();
+
+    expect(test.assert).toHaveProperty('nested', expect.any(Function));
+    expect(test.assert.nested).toHaveProperty('passing', expect.any(Function));
+    expect(test.nested.assert).toBeUndefined();
+    expect(test.nested.only().assert).toHaveProperty('passing', expect.any(Function));
+
+    pass = true;
+    expect(test.assert.nested.passing()).toBeInstanceOf(NestedInteractor);
+    await expect(test.assert.nested.passing()).resolves.toBeUndefined();
+  });
+
   describe('making assertions', () => {
     it('resolves when passing', async () => {
       await expect(instance.assert(() => expect(pass).toBeNull()))

--- a/tests/helpers/collection.test.js
+++ b/tests/helpers/collection.test.js
@@ -118,6 +118,15 @@ describe('Interactor helpers - collection', () => {
     expect(test.assert.items().count(4)).toBeInstanceOf(CollectionInteractor);
   });
 
+  it('returns new parent instances from deeply nested collection assertions', () => {
+    @interactor class DeepInteractor { test = test }
+    let deep = new DeepInteractor();
+
+    expect(deep.test.items(0).assert.matches('.a')).toBeInstanceOf(DeepInteractor);
+    expect(deep.test.assert.items(0).matches('.a')).toBeInstanceOf(DeepInteractor);
+    expect(deep.test.assert.items().count(4)).toBeInstanceOf(DeepInteractor);
+  });
+
   it('throws scoped assertion errors for computed selectors', async () => {
     await expect(test.assert.byClassName('a').matches('.b'))
       .rejects.toThrow('".a" assertion failed');

--- a/tests/helpers/collection.test.js
+++ b/tests/helpers/collection.test.js
@@ -99,7 +99,6 @@ describe('Interactor helpers - collection', () => {
   });
 
   it('has nested collection assertions', async () => {
-    await expect(test.items(0).assert.matches('.a')).resolves.toBeUndefined();
     await expect(test.assert.items(0).matches('.a')).resolves.toBeUndefined();
   });
 
@@ -113,7 +112,6 @@ describe('Interactor helpers - collection', () => {
   });
 
   it('returns new parent instances from collection assertions', () => {
-    expect(test.items(0).assert.matches('.a')).toBeInstanceOf(CollectionInteractor);
     expect(test.assert.items(0).matches('.a')).toBeInstanceOf(CollectionInteractor);
     expect(test.assert.items().count(4)).toBeInstanceOf(CollectionInteractor);
   });
@@ -122,9 +120,8 @@ describe('Interactor helpers - collection', () => {
     @interactor class DeepInteractor { test = test }
     let deep = new DeepInteractor();
 
-    expect(deep.test.items(0).assert.matches('.a')).toBeInstanceOf(DeepInteractor);
-    expect(deep.test.assert.items(0).matches('.a')).toBeInstanceOf(DeepInteractor);
-    expect(deep.test.assert.items().count(4)).toBeInstanceOf(DeepInteractor);
+    expect(deep.assert.test.items(0).matches('.a')).toBeInstanceOf(DeepInteractor);
+    expect(deep.assert.test.items().count(4)).toBeInstanceOf(DeepInteractor);
   });
 
   it('throws scoped assertion errors for computed selectors', async () => {

--- a/tests/helpers/scoped.test.js
+++ b/tests/helpers/scoped.test.js
@@ -73,8 +73,6 @@ describe('Interactor helpers - scoped', () => {
 
     describe('and nested assertions', () => {
       it('returns a parent instance from nested assertions', () => {
-        expect(new ScopedInteractor().p.assert.text('A'))
-          .toBeInstanceOf(ScopedInteractor);
         expect(new ScopedInteractor().assert.p.text('A'))
           .toBeInstanceOf(ScopedInteractor);
       });
@@ -82,7 +80,7 @@ describe('Interactor helpers - scoped', () => {
       it('can chain nested assertions', async () => {
         await expect(
           new ScopedInteractor('#scoped')
-            .p.assert.not.text('A')
+            .assert.p.not.text('A')
             .assert.p.text('B')
         ).resolves.toBeUndefined();
       });


### PR DESCRIPTION
## Purpose

- Deeply nested collection count assertions did not return the topmost parent.
- `name` and `length` assertions triggered an assignment error on the bound `assert` function.
- `check` and `uncheck` actions did not trigger click events. Radio buttons also cannot be unchecked without checking a different radio button.
- `assert` should be top-level only

## Approach

- Add parent append logic to the collection count assertion since collection assertions do not get wrapped in `chainable`.
- Move assertion assignments into defining property descriptors so they no longer trigger assignment errors.
- Instead of setting `element.checked` and triggering `change` and `input` events, simply call `element.click` which accomplishes the same thing in addition to sending a click event.
- Remove the assert property from chained interactors and use assert helpers to return nested assertions.

This will release v1.4.3