### PR TITLE
Fix decorator class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix class methods not getting wrapped when using the decorator
+
 ## [1.4.3] - 2019-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.4.4] - 2019-06-27
+
 ### Fixed
 
 - Fix class methods not getting wrapped when using the decorator

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -59,7 +59,12 @@ function wrap(from) {
 function toInteractorDescriptor(from) {
   // already a property descriptor
   if (isPropertyDescriptor(from)) {
-    return from;
+    // function descriptors still get wrapped
+    if ('value' in from && typeof from.value === 'function') {
+      return { value: wrap(from.value) };
+    } else {
+      return from;
+    }
 
   // nested interactors get parent references
   } else if (isInteractor(from)) {

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -798,7 +798,9 @@ describe('Interactor', () => {
           return this.getgot;
         },
 
-        func() {},
+        func() {
+          return new Interactor().do(() => {});
+        },
 
         descr: {
           enumerable: false,
@@ -844,6 +846,11 @@ describe('Interactor', () => {
 
     it('creates an interactor class with interactor actions', () => {
       expect(TestInteractor.prototype).toHaveProperty('action', expect.any(Function));
+    });
+
+    it('returns the topmost interactor from interactor actions', () => {
+      expect(new TestInteractor().func()).toBeInstanceOf(TestInteractor);
+      expect(new TestInteractor().action()).toBeInstanceOf(TestInteractor);
     });
 
     it('creates an interactor class from the origin class', () => {
@@ -899,7 +906,9 @@ describe('Interactor', () => {
           return this.getgot;
         }
 
-        func() {}
+        func() {
+          return new Interactor().do(() => {});
+        }
 
         test = {
           enumerable: false,
@@ -945,6 +954,11 @@ describe('Interactor', () => {
 
     it('extends the interactor class with interactor actions', () => {
       expect(TestInteractor.prototype).toHaveProperty('action', expect.any(Function));
+    });
+
+    it('returns the topmost interactor from interactor actions', () => {
+      expect(new TestInteractor().func()).toBeInstanceOf(TestInteractor);
+      expect(new TestInteractor().action()).toBeInstanceOf(TestInteractor);
     });
 
     it('extends the interactor class from the origin class', () => {


### PR DESCRIPTION
## Purpose

When using the decorator, class methods are not wrapped properly. So when returning actions (interactors with a queue), they were not getting appended up the parent chain properly.

## Approach

Since the decorator uses from, but with descriptors from the class prototype, we need to account for methods that may be passed as descriptors instead of normal functions.

When creating interactor descriptors, if given a descriptor, first check if it's a function descriptor and wrap it if so.

This will release v1.4.4