### PR TITLE
Fix assigning properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Properties being unassignable due to default descriptor options
+
 ## [1.4.5] - 2019-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.4.6] - 2019-08-23
+
 ### Fixed
 
 - Properties being unassignable due to default descriptor options

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -56,34 +56,39 @@ function wrap(from) {
   };
 }
 
+function descr({ value, get } = {}) {
+  let d = { configurable: true, enumerable: false };
+  return get ? assign(d, { get }) : assign(d, { value, writable: true });
+}
+
 function toInteractorDescriptor(from) {
   // already a property descriptor
   if (isPropertyDescriptor(from)) {
     // function descriptors still get wrapped
     if ('value' in from && typeof from.value === 'function') {
-      return { value: wrap(from.value) };
+      return descr({ value: wrap(from.value) });
     } else {
-      return from;
+      return descr(from);
     }
 
   // nested interactors get parent references
   } else if (isInteractor(from)) {
     // action interactors are functions
     if (get(from, 'queue').length > 0) {
-      return { value: wrap(from) };
+      return descr({ value: wrap(from) });
 
     // all other interactors are getters
     } else {
-      return { get: wrap(from) };
+      return descr({ get: wrap(from) });
     }
 
   // wrap functions in case they return interactors
   } else if (typeof from === 'function') {
-    return { value: wrap(from) };
+    return descr({ value: wrap(from) });
 
   // preserve all other values
   } else {
-    return { value: from };
+    return descr({ value: from });
   }
 }
 

--- a/tests/core/interactor.test.js
+++ b/tests/core/interactor.test.js
@@ -855,10 +855,12 @@ describe('Interactor', () => {
 
     it('creates an interactor class from the origin class', () => {
       let ExtendedInteractor = TestInteractor.from({
-        bar: { enumerable: false, configurable: false, get: () => 'baz' }
+        bar: { enumerable: false, configurable: false, get: () => 'baz' },
+        click: 'clack'
       });
 
       expect(new ExtendedInteractor()).toHaveProperty('bar', 'baz');
+      expect(new ExtendedInteractor()).toHaveProperty('click', 'clack');
       expect(new ExtendedInteractor()).toBeInstanceOf(TestInteractor);
     });
 
@@ -964,9 +966,11 @@ describe('Interactor', () => {
     it('extends the interactor class from the origin class', () => {
       @interactor class ExtendedInteractor extends TestInteractor {
         bar = { enumerable: false, configurable: false, get: () => 'baz' };
+        click = 'clack';
       }
 
       expect(new ExtendedInteractor()).toHaveProperty('bar', 'baz');
+      expect(new ExtendedInteractor()).toHaveProperty('click', 'clack');
       expect(new ExtendedInteractor()).toBeInstanceOf(TestInteractor);
     });
 


### PR DESCRIPTION
## Purpose

When overriding ancestor properties from extended interactors using the decorator syntax, an error was thrown about the property not being assignable (missing `writable` in descriptor).

## Approach

When creating interactor descriptors, ensure they are always configurable and writable but not enumerable (since they are meant to be prototype properties).

Releases v1.4.6