### PR TITLE
Allow regex matchers for attributes, text, and value assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.5.0] - 2019-09-15
+
+### Added
+
+- Regex matchers for value, text, and attribute assertions
+- Assertion message functions receive the value of assertion results
+
 ## [1.4.6] - 2019-08-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with DOM",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",

--- a/src/assertions/attribute.js
+++ b/src/assertions/attribute.js
@@ -1,13 +1,13 @@
 import method, { args } from '../helpers/attribute';
-import { sel } from '../utils/string';
+import { sel, q, eq } from '../utils/string';
 
 export function validate(selector, attr) {
   return (actual, expected) => ({
-    result: actual === expected,
-    message: sel(selector, () => (
-      actual === expected
-        ? `%s "${attr}" is "${expected}"`
-        : `%s "${attr}" is "${actual}" but expected "${expected}"`
+    result: eq(actual, expected),
+    message: sel(selector, result => (
+      result
+        ? `%s "${attr}" is ${q(expected)}`
+        : `%s "${attr}" is ${q(actual)} but expected ${q(expected)}`
     ))
   });
 }

--- a/src/properties/text.js
+++ b/src/properties/text.js
@@ -1,16 +1,15 @@
 import computed from '../helpers/computed';
+import { q, eq } from '../utils/string';
 
 export default function text(selector) {
   return computed(
     selector,
     element => element.innerText,
     (actual, expected) => ({
-      result: actual === expected,
-      message: () => (
-        actual === expected
-          ? `%s text is "${expected}"`
-          : `%s text is "${actual}" but expected "${expected}"`
-      )
+      result: eq(actual, expected),
+      message: result => result
+        ? `%s text is ${q(expected)}`
+        : `%s text is ${q(actual)} but expected ${q(expected)}`
     })
   );
 }

--- a/src/properties/value.js
+++ b/src/properties/value.js
@@ -1,16 +1,15 @@
 import computed from '../helpers/computed';
+import { q, eq } from '../utils/string';
 
 export default function value(selector) {
   return computed(
     selector,
     element => element.value,
     (actual, expected) => ({
-      result: actual === expected,
-      message: () => (
-        actual === expected
-          ? `%s value is "${expected}"`
-          : `%s value is "${actual}" but expected "${expected}"`
-      )
+      result: eq(actual, expected),
+      message: result => result
+        ? `%s value is ${q(expected)}`
+        : `%s value is ${q(actual)} but expected ${q(expected)}`
     })
   );
 }

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -81,7 +81,7 @@ function validate(interactor) {
         throw new Error(
           format
             .replace('%s', getScopeName(ctx))
-            .replace('%e', message())
+            .replace('%e', message(result))
         );
       }
 

--- a/src/utils/from.js
+++ b/src/utils/from.js
@@ -4,7 +4,7 @@ import isInteractor from './is-interactor';
 import createAsserts, { getAssertFor } from './assert';
 import { chainAssert } from './chainable';
 import meta, { set, get } from './meta';
-import { sel, q } from './string';
+import { sel, q, eq } from './string';
 
 const {
   assign,
@@ -151,11 +151,7 @@ function toInteractorAssertion(name, from) {
         let result = !!actual;
 
         if (args.length > 1) {
-          if (typeof actual === 'string' && expected instanceof RegExp) {
-            result = expected.test(actual);
-          } else {
-            result = actual === expected;
-          }
+          result = eq(actual, expected);
         }
 
         return {

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,5 +1,5 @@
 export function sel(selector, message) {
-  return () => message()
+  return result => message(result)
     .replace('%s', selector ? `"${selector}"` : '')
     .trim();
 }
@@ -8,4 +8,12 @@ export function q(value) {
   return typeof value === 'string'
     ? `"${value}"`
     : value;
+}
+
+export function eq(actual, expected) {
+  if (typeof actual === 'string' && expected instanceof RegExp) {
+    return expected.test(actual);
+  } else {
+    return actual === expected;
+  }
 }

--- a/tests/assertions/attribute.test.js
+++ b/tests/assertions/attribute.test.js
@@ -16,26 +16,38 @@ describe('Interactor assertions - attribute', () => {
 
     it('resolves when passing', async () => {
       await expect(div.assert.attribute('data-foo', 'bar')).resolves.toBeUndefined();
+      await expect(div.assert.attribute('data-foo', /b.r/)).resolves.toBeUndefined();
       await expect(div.assert.not.attribute('data-bar', 'baz')).resolves.toBeUndefined();
+      await expect(div.assert.not.attribute('data-bar', /b.z/)).resolves.toBeUndefined();
     });
 
     it('resolves when passing with a selector', async () => {
       await expect(test.assert.attribute('.foobar', 'data-foo', 'bar')).resolves.toBeUndefined();
+      await expect(test.assert.attribute('.foobar', 'data-foo', /b.r/)).resolves.toBeUndefined();
       await expect(test.assert.not.attribute('.foobar', 'data-bar', 'baz')).resolves.toBeUndefined();
+      await expect(test.assert.not.attribute('.foobar', 'data-bar', /b.z/)).resolves.toBeUndefined();
     });
 
     it('rejects with an error when failing', async () => {
       await expect(div.assert.attribute('data-foo', 'baz'))
         .rejects.toThrow('"data-foo" is "bar" but expected "baz"');
+      await expect(div.assert.attribute('data-foo', /b.z/))
+        .rejects.toThrow('"data-foo" is "bar" but expected /b.z/');
       await expect(div.assert.not.attribute('data-foo', 'bar'))
         .rejects.toThrow('"data-foo" is "bar"');
+      await expect(div.assert.not.attribute('data-foo', /b.r/))
+        .rejects.toThrow('"data-foo" is /b.r/');
     });
 
     it('rejects with an error when failing with a selector', async () => {
       await expect(test.assert.attribute('.foobar', 'data-foo', 'baz'))
         .rejects.toThrow('".foobar" "data-foo" is "bar" but expected "baz"');
+      await expect(test.assert.attribute('.foobar', 'data-foo', /b.z/))
+        .rejects.toThrow('".foobar" "data-foo" is "bar" but expected /b.z/');
       await expect(test.assert.not.attribute('.foobar', 'data-foo', 'bar'))
         .rejects.toThrow('".foobar" "data-foo" is "bar"');
+      await expect(test.assert.not.attribute('.foobar', 'data-foo', /b.r/))
+        .rejects.toThrow('".foobar" "data-foo" is /b.r/');
     });
   });
 });

--- a/tests/properties/text.test.js
+++ b/tests/properties/text.test.js
@@ -22,26 +22,38 @@ describe('Interactor properties - text', () => {
     describe('and the default assertion', () => {
       it('resolves when passing', async () => {
         await expect(p.assert.text('Hello WORLD!')).resolves.toBeUndefined();
+        await expect(p.assert.text(/world/i)).resolves.toBeUndefined();
         await expect(p.assert.not.text('WORLD')).resolves.toBeUndefined();
+        await expect(p.assert.not.text(/wild/)).resolves.toBeUndefined();
       });
 
       it('resolves when passing with a selector', async () => {
         await expect(p.assert.text('span', 'WORLD')).resolves.toBeUndefined();
+        await expect(p.assert.text('span', /wo/i)).resolves.toBeUndefined();
         await expect(p.assert.not.text('span', 'Hello WORLD!')).resolves.toBeUndefined();
+        await expect(p.assert.not.text('span', /hello/i)).resolves.toBeUndefined();
       });
 
       it('rejects with an error when failing', async () => {
         await expect(p.assert.text('hello world'))
           .rejects.toThrow('text is "Hello WORLD!" but expected "hello world"');
+        await expect(p.assert.text(/world/))
+          .rejects.toThrow('text is "Hello WORLD!" but expected /world/');
         await expect(p.assert.not.text('Hello WORLD!'))
           .rejects.toThrow('text is "Hello WORLD!"');
+        await expect(p.assert.not.text(/world/i))
+          .rejects.toThrow('text is /world/i');
       });
 
       it('rejects with an error when failing with a selector', async () => {
         await expect(p.assert.text('span', 'world'))
           .rejects.toThrow('text is "WORLD" but expected "world"');
+        await expect(p.assert.text('span', /world/))
+          .rejects.toThrow('text is "WORLD" but expected /world/');
         await expect(p.assert.not.text('span', 'WORLD'))
           .rejects.toThrow('text is "WORLD"');
+        await expect(p.assert.not.text('span', /world/i))
+          .rejects.toThrow('text is /world/i');
       });
     });
   });
@@ -62,14 +74,20 @@ describe('Interactor properties - text', () => {
     describe('and the default assertion', () => {
       it('resolves when passing', async () => {
         await expect(p.assert.text('WORLD')).resolves.toBeUndefined();
+        await expect(p.assert.text(/world/i)).resolves.toBeUndefined();
         await expect(p.assert.not.text('Hello')).resolves.toBeUndefined();
+        await expect(p.assert.not.text(/wo/)).resolves.toBeUndefined();
       });
 
       it('rejects with an error when failing', async () => {
         await expect(p.assert.text('Hello WORLD!'))
           .rejects.toThrow('text is "WORLD" but expected "Hello WORLD!"');
+        await expect(p.assert.text(/hello/i))
+          .rejects.toThrow('text is "WORLD" but expected /hello/i');
         await expect(p.assert.not.text('WORLD'))
           .rejects.toThrow('text is "WORLD"');
+        await expect(p.assert.not.text(/world/i))
+          .rejects.toThrow('text is /world/i');
       });
     });
 
@@ -80,14 +98,20 @@ describe('Interactor properties - text', () => {
 
       it('resolves when passing', async () => {
         await expect(p.assert.foo('WORLD')).resolves.toBeUndefined();
+        await expect(p.assert.foo(/world/i)).resolves.toBeUndefined();
         await expect(p.assert.not.foo('Hello')).resolves.toBeUndefined();
+        await expect(p.assert.not.foo(/wo/)).resolves.toBeUndefined();
       });
 
       it('rejects with an error when failing', async () => {
         await expect(p.assert.foo('Hello WORLD!'))
           .rejects.toThrow('text is "WORLD" but expected "Hello WORLD!"');
+        await expect(p.assert.text(/hello/i))
+          .rejects.toThrow('text is "WORLD" but expected /hello/i');
         await expect(p.assert.not.foo('WORLD'))
           .rejects.toThrow('text is "WORLD"');
+        await expect(p.assert.not.text(/world/i))
+          .rejects.toThrow('text is /world/i');
       });
     });
   });

--- a/tests/properties/value.test.js
+++ b/tests/properties/value.test.js
@@ -24,26 +24,38 @@ describe('Interactor properties - value', () => {
 
       it('resolves when passing', async () => {
         await expect(input.assert.value('hello world')).resolves.toBeUndefined();
+        await expect(input.assert.value(/world/)).resolves.toBeUndefined();
         await expect(input.assert.not.value('HELLO')).resolves.toBeUndefined();
+        await expect(input.assert.not.value(/hi/)).resolves.toBeUndefined();
       });
 
       it('resolves when passing with a selector', async () => {
         await expect(field.assert.value('input', 'hello world')).resolves.toBeUndefined();
+        await expect(field.assert.value('input', /w.r.d/)).resolves.toBeUndefined();
         await expect(field.assert.not.value('input', 'HELLO')).resolves.toBeUndefined();
+        await expect(field.assert.not.value('input', /h{2}/)).resolves.toBeUndefined();
       });
 
       it('rejects with an error when failing', async () => {
         await expect(input.assert.value('hallo worldo'))
           .rejects.toThrow('value is "hello world" but expected "hallo worldo"');
+        await expect(input.assert.value(/hi/i))
+          .rejects.toThrow('value is "hello world" but expected /hi/i');
         await expect(input.assert.not.value('hello world'))
           .rejects.toThrow('value is "hello world"');
+        await expect(input.assert.not.value(/world/))
+          .rejects.toThrow('value is /world/');
       });
 
       it('rejects with an error when failing with a selector', async () => {
         await expect(field.assert.value('input', 'hallo worldo'))
           .rejects.toThrow('value is "hello world" but expected "hallo worldo"');
+        await expect(field.assert.value('input', /WORLD/))
+          .rejects.toThrow('value is "hello world" but expected /WORLD/');
         await expect(field.assert.not.value('input', 'hello world'))
           .rejects.toThrow('value is "hello world"');
+        await expect(field.assert.not.value('input', /l{2}/))
+          .rejects.toThrow('value is /l{2}/');
       });
     });
   });
@@ -64,14 +76,20 @@ describe('Interactor properties - value', () => {
     describe('and the default assertion', () => {
       it('resolves when passing', async () => {
         await expect(field.assert.value('hello world')).resolves.toBeUndefined();
+        await expect(field.assert.value(/world/)).resolves.toBeUndefined();
         await expect(field.assert.not.value('HELLO')).resolves.toBeUndefined();
+        await expect(field.assert.not.value(/WORLD/)).resolves.toBeUndefined();
       });
 
       it('rejects with an error when failing', async () => {
         await expect(field.assert.value('hallo worldo'))
           .rejects.toThrow('value is "hello world" but expected "hallo worldo"');
+        await expect(field.assert.value(/hallo/))
+          .rejects.toThrow('value is "hello world" but expected /hallo/');
         await expect(field.assert.not.value('hello world'))
           .rejects.toThrow('value is "hello world"');
+        await expect(field.assert.not.value(/h.llo/))
+          .rejects.toThrow('value is /h.llo/');
       });
     });
 
@@ -82,14 +100,20 @@ describe('Interactor properties - value', () => {
 
       it('resolves when passing', async () => {
         await expect(field.assert.foo('hello world')).resolves.toBeUndefined();
+        await expect(field.assert.foo(/w.r.d/)).resolves.toBeUndefined();
         await expect(field.assert.not.foo('HELLO')).resolves.toBeUndefined();
+        await expect(field.assert.not.foo(/h{2}/)).resolves.toBeUndefined();
       });
 
       it('rejects with an error when failing', async () => {
         await expect(field.assert.foo('hallo worldo'))
           .rejects.toThrow('value is "hello world" but expected "hallo worldo"');
+        await expect(field.assert.foo(/ha/))
+          .rejects.toThrow('value is "hello world" but expected /ha/');
         await expect(field.assert.not.foo('hello world'))
           .rejects.toThrow('value is "hello world"');
+        await expect(field.assert.not.foo(/h.l{2}o/))
+          .rejects.toThrow('value is /h.l{2}o/');
       });
     });
   });


### PR DESCRIPTION
## Purpose

[#20 - Allow regular expressions for some built-in property assertions](https://github.com/wwilsman/interactor.js/issues/20)

## Approach

Assertion results are now passed on to the matcher message to enable a compact way to avoid recomputing possibly expensive assertion results.

The logic for auto-defined matchers and regex values was extracted into a utility function. That utility function, along with the message function receiving the assertion results, was utilized for `attribute`, `text`, and `value` assertion matchers.