### PR TITLE
Improve color contrast for text

### DIFF
--- a/src/components/layout/layout.module.css
+++ b/src/components/layout/layout.module.css
@@ -99,7 +99,11 @@ body > div > div {
     }
 
     a {
-      color: #f0db50;
+      color: black;
+
+      svg {
+        color: #f0db50;
+      }
     }
 
     li {

--- a/src/components/page-nav/page-nav.module.css
+++ b/src/components/page-nav/page-nav.module.css
@@ -21,7 +21,7 @@
 
     &:hover {
       border-color: #F0DB50;
-      color: #F0DB50;
+      color: black;
 
       svg {
         color: #F0DB50;

--- a/src/components/tabbed/tabbed.module.css
+++ b/src/components/tabbed/tabbed.module.css
@@ -20,7 +20,7 @@
     }
 
     &.is-active {
-      color: #F0DB50;
+      color: black;
     }
   }
 }


### PR DESCRIPTION
As [this kind user](https://twitter.com/knownasilya/status/1214679997794967554) has pointed out, yellow on white is a little harsh on the eyes. 

This makes the text color black for links, black on hover for page nav, and active code tabs are also now black.