### PR TITLE
🐛 Correctly scope extended custom interactors

### DIFF
--- a/src/helpers/scoped.js
+++ b/src/helpers/scoped.js
@@ -20,10 +20,14 @@ export default function scoped(selector, properties) {
   let proto = properties && getPrototypeOf(properties);
   let ScopedInteractor = Interactor;
 
-  if (proto === Interactor || proto instanceof Interactor) {
-    ScopedInteractor = properties;
-  } else if (proto === Object.prototype) {
-    ScopedInteractor = Interactor.from(properties);
+  if (proto) {
+    if (proto === Interactor ||
+        proto instanceof Interactor ||
+        proto.prototype instanceof Interactor) {
+      ScopedInteractor = properties;
+    } else if (proto === Object.prototype) {
+      ScopedInteractor = Interactor.from(properties);
+    }
   }
 
   return new ScopedInteractor({

--- a/tests/helpers/scoped.test.js
+++ b/tests/helpers/scoped.test.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 
 import { injectHtml } from '../helpers';
-import interactor, { Interactor, scoped } from 'interactor.js';
+import interactor, { Interactor, scoped, text } from 'interactor.js';
 import { get } from '../../src/utils/meta';
 
 describe('Interactor helpers - scoped', () => {
@@ -141,6 +141,24 @@ describe('Interactor helpers - scoped', () => {
       expect(get(next, 'queue')).toHaveLength(3);
 
       await expect(next).resolves.toBeUndefined();
+    });
+  });
+
+  describe('with custom interactors', () => {
+    @interactor class FooInteractor {
+      bar = text('.test-p');
+    }
+
+    @interactor class TestInteractor {
+      foo = scoped('#test', FooInteractor.from({
+        baz: text('#scoped .test-p')
+      }));
+    }
+
+    it('correctly inherits properties', async () => {
+      let test = new TestInteractor();
+      expect(test.foo.bar).toEqual('A');
+      expect(test.foo.baz).toEqual('B');
     });
   });
 });


### PR DESCRIPTION
## Purpose

Fixes #25 

Upon investigation, it seems there was already a similar test within the core functionality. The actual bug exists within the scope helper when it cannot correctly detect that the provided interactor is in fact an interactor.

## Approach

Similar to how the decorator checks instances when extending from existing interactors, the scope helper should also check if the `prototype` property is an instance of an interactor. The entire logic block was wrapped in an extra check to ensure that `properties` was provided at all to prevent undefined errors.

### Questions

- Do these checks work for interactors that are even more deeply extended? This should be tested and if found that it does not work, there probably needs to be a recursive helper that looks up the prototype chain. Holding off on testing this for now pending a possible future v2 with minimal breaking changes to make things a bit more robust.