### PR TITLE
♻️ Move find action behavior to exec method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactor.js",
   "description": "Composable, immutable, asynchronous way to interact with the DOM",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "repository": "https://github.com/wwilsman/interactor.js",
   "main": "dist/umd/index.js",
@@ -15,8 +15,9 @@
     "lint": "eslint --ignore-path .gitignore ./",
     "test": "NODE_ENV=test karma start",
     "test:watch": "yarn test --no-single-run",
-    "test:jsdom": "yarn test --browsers jsdom",
     "test:coverage": "yarn test --coverage json",
+    "test:jsdom": "yarn test --browsers jsdom",
+    "test:jsdom:watch": "yarn test:jsdom --no-single-run",
     "test:jsdom:coverage": "yarn test:jsdom --coverage json"
   },
   "devDependencies": {

--- a/src/extend.js
+++ b/src/extend.js
@@ -49,7 +49,7 @@ function wrapProperty({ get, value }) {
       if (queue && !m.eq(this, ret)) {
         // append its queue or associate it with the parent interactor
         return queue.length && !get
-          ? this.find(ret)
+          ? this.exec(ret)
           : m.new(ret, 'parent', this);
       }
 

--- a/tests/interactor.test.js
+++ b/tests/interactor.test.js
@@ -287,19 +287,12 @@ describe('Interactor', () => {
         assert.instanceOf(next, Bar);
         assert.instanceOf(next.exec(), Foo);
       });
-    });
 
-    describe('with an interactor action', () => {
-      it('returns an new instance of the topmost interactor', () => {
-        let next = Foo('.a').find(Bar('.b').exec());
-        assert.instanceOf(next, Foo);
-        assert.instanceOf(next.exec(), Foo);
-      });
-
-      it('appends actions to the next queue', async () => {
-        let called = false;
-        await Foo('.a').find(Bar('.b').exec(() => (called = true)));
-        assert.equal(called, true);
+      it('throws when the interactor has queued actions', () => {
+        assert.throws(
+          () => Foo('.a').find(Bar('.b').exec()),
+          e('InteractorError', 'the provided interactor must not have queued actions')
+        );
       });
     });
   });
@@ -331,6 +324,23 @@ describe('Interactor', () => {
             .assert(() => (count *= 2))
             .assert(() => assert.equal(count, 40))
         );
+      });
+    });
+
+    describe('with an interactor action', () => {
+      const Foo = Interactor.extend();
+      const Bar = Interactor.extend();
+
+      it('returns an new instance of the topmost interactor', () => {
+        let next = Foo().exec(Bar().exec());
+        assert.instanceOf(next, Foo);
+        assert.instanceOf(next.exec(), Foo);
+      });
+
+      it('appends actions to the next queue', async () => {
+        let called = false;
+        await Foo().exec(Bar().exec(() => (called = true)));
+        assert.equal(called, true);
       });
     });
   });


### PR DESCRIPTION
## Purpose

Currently, `.find` has two differing behaviors given an interactor.

Given an interactor without queued actions:

``` javascript
ParentInteractor.find(ChildInteractor): ParentChildInteractor
```

Given an interactor with queue actions:

``` javascript
ParentInteractor.find(ChildInteractor): ParentInteractor
```

## Approach

Move the behavior to the `.exec` action where it not only reads better, but has a consistent return value

```javascript
ParentInteractor.exec(Function): ParentInteractor
ParentInteractor.exec(ChildInteractor): ParentInteractor
```

Providing an interactor with queued actions to the `.find` method will now result in an error.