### PR TITLE
⬆️ Bump `moonshiner` to `0.15.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "istanbul-lib-coverage": "^3.2.2",
-        "moonshiner": "^0.15.0",
+        "moonshiner": "^0.15.2",
         "nyc": "^15.1.0",
         "rollup": "^4.9.6",
         "rollup-plugin-glob-import": "^0.5.0",
@@ -5374,9 +5374,9 @@
       "dev": true
     },
     "node_modules/moonshiner": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/moonshiner/-/moonshiner-0.15.0.tgz",
-      "integrity": "sha512-BmqcCPSzzdzv8aG8NMGevnWooX2Jpt/7QA+m2BNFXJemHEVmbUj9031CJlkd8HK7H2aX+VMBo6/oW1qRLEaQbQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/moonshiner/-/moonshiner-0.15.2.tgz",
+      "integrity": "sha512-We0UGfIErQ02+RWiHA61aGKr0CrDZa8vW2SWrUADptBwwIZ+UwVSZP3CujcPbwVm9cmIRYuEFSobgvm+N4kEVw==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "istanbul-lib-coverage": "^3.2.2",
-    "moonshiner": "^0.15.0",
+    "moonshiner": "^0.15.2",
     "nyc": "^15.1.0",
     "rollup": "^4.9.6",
     "rollup-plugin-glob-import": "^0.5.0",


### PR DESCRIPTION
## What is this?

This upgrades `moonshiner` to the latest version to mainly fix downloading the test browser (among a few other bug fixes) 